### PR TITLE
Update sca.py

### DIFF
--- a/veracode_api_py/sca.py
+++ b/veracode_api_py/sca.py
@@ -90,7 +90,7 @@ class Workspaces():
           return APIHelper()._rest_request(uri, "GET" )
 
      def regenerate_agent_token(self,workspace_guid: UUID, agent_guid: UUID):
-          uri = self.sca_base_url + '/{}/agents/{}/tokens:regenerate'.format(workspace_guid,agent_guid)
+          uri = self.sca_base_url + '/{}/agents/{}/token:regenerate'.format(workspace_guid,agent_guid)
           return APIHelper()._rest_request(uri,"POST")
 
      def revoke_agent_token(self,workspace_guid: UUID, agent_guid: UUID, token_id: UUID):


### PR DESCRIPTION
Corrected SCA Token regeneration endpoint. Calls to API method are returning 404. Endpoint called by API library does not match swagger docs https://app.swaggerhub.com/apis/Veracode/veracode-sca_agent_api_specification/3.0#/agents/renewWorkspaceAgentTokenUsingPOST